### PR TITLE
🔧 Fix typo in comment on line 21 of `Encoding.sol`

### DIFF
--- a/src/sublesson/Encoding.sol
+++ b/src/sublesson/Encoding.sol
@@ -18,7 +18,7 @@ contract Encoding {
     // creating a contract.
 
     // This bytecode represents exactly the low level computer instructions to make our contract happen.
-    // These low level instructions are spread out into soemthing call opcodes.
+    // These low level instructions are spread out into something called opcodes.
 
     // An opcode is going to be 2 characters that represents some special instruction, and also optionally has an input
 


### PR DESCRIPTION
### Summary

This PR corrects a minor typo #47  in the comment on line 21 of the `Encoding.sol` contract.

### What Was Changed

**Before:**
```solidity
// These low level instructions are spread out into soemthing call opcodes.
```

**After:**
```solidity
// These low level instructions are spread out into something called opcodes.
```

### Why This Matters

Fixing typos in comments improves code readability and professionalism, especially in educational or reference materials like this repo.