### PR TITLE
fix: remove onlyVanillaFoundry to support non-standard Foundry setups

### DIFF
--- a/test/MoodNftTest.sol
+++ b/test/MoodNftTest.sol
@@ -66,7 +66,8 @@ contract MoodNftTest is Test, ZkSyncChainChecker, FoundryZkSyncChecker {
     }
 
     // logging events doesn't work great in foundry-zksync
-    function testEventRecordsCorrectTokenIdOnMinting() public onlyVanillaFoundry {
+    function testEventRecordsCorrectTokenIdOnMinting() public  { // Removed `onlyVanillaFoundry` to allow compatibility with custom Foundry setups and zkSync chains.
+
         uint256 currentAvailableTokenId = moodNft.getTokenCounter();
 
         vm.prank(USER);


### PR DESCRIPTION
This PR removes the `onlyVanillaFoundry` modifier from `testEventRecordsCorrectTokenIdOnMinting` to allow the test to run in environments where Foundry version is not detected correctly, such as ZkSync or patched chains.

Tested locally with:
- Anvil
- forge test
